### PR TITLE
fix .proj file

### DIFF
--- a/stanza.proj
+++ b/stanza.proj
@@ -7,11 +7,11 @@ packages z3/tests/* defined-in "tests/"
 package z3/Wrapper requires :
   dynamic-libraries:
     on-platform:
-      windows: "./build/content/libz3.dll"
-      linux: "./build/content/libz3.so"
-      os-x: "./build/content/libz3.dylib"
-  ccfiles: "./build/content/libz3.a"
-  ccflags: "-I./build/content/include"
+      windows: "./build/shared/full_deploy/host/z3/4.12.2/Release/x86_64/lib/libz3.dll"
+      linux: "./build/shared/full_deploy/host/z3/4.12.2/Release/x86_64/lib/libz3.so"
+      os-x: "./build/shared/full_deploy/host/z3/4.12.2/Release/x86_64/lib/libz3.dylib"
+  ccfiles: "./build/deps/lib/libz3.a"
+  ccflags: "-I./build/deps/include"
 
 build main :
   inputs:


### PR DESCRIPTION
Conan-izing seems like moved the C dependencies around. This is a minimal update to the .proj file to get everything to build again.

I think Jason's conan PR might accomplish this in a more general way.